### PR TITLE
Add working hours config, coming-soon views, and confirm dialog

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub llm: LlmConfig,
     #[serde(default)]
+    pub working_hours: WorkingHoursConfig,
+    #[serde(default)]
     pub dashboard_layout: HashMap<String, CardPosition>,
 }
 
@@ -44,6 +46,7 @@ impl Default for AppConfig {
             slack: SlackConfig::default(),
             notion: NotionConfig::default(),
             llm: LlmConfig::default(),
+            working_hours: WorkingHoursConfig::default(),
             dashboard_layout: HashMap::new(),
         }
     }
@@ -232,6 +235,55 @@ impl Default for SlackConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NotionConfig {
     // Tokens are stored in the system keychain, not in config.
+}
+
+// ---------------------------------------------------------------------------
+// Working Hours
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkingHoursConfig {
+    #[serde(default = "default_work_start")]
+    pub work_start: String,
+    #[serde(default = "default_work_end")]
+    pub work_end: String,
+    #[serde(default = "default_working_days")]
+    pub working_days: Vec<String>,
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
+}
+
+impl Default for WorkingHoursConfig {
+    fn default() -> Self {
+        Self {
+            work_start: default_work_start(),
+            work_end: default_work_end(),
+            working_days: default_working_days(),
+            timezone: default_timezone(),
+        }
+    }
+}
+
+fn default_work_start() -> String {
+    "09:00".to_string()
+}
+
+fn default_work_end() -> String {
+    "17:00".to_string()
+}
+
+fn default_working_days() -> Vec<String> {
+    vec![
+        "Mon".to_string(),
+        "Tue".to_string(),
+        "Wed".to_string(),
+        "Thu".to_string(),
+        "Fri".to_string(),
+    ]
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/app.js
+++ b/ui/app.js
@@ -655,18 +655,19 @@ function switchView(view) {
   // Show target
   const el = document.getElementById(`view-${view}`);
   if (el) el.style.display = '';
-  // Hide date controls + period tabs on Trends (it's always trailing 12 weeks)
+  // Hide date controls + period tabs on Trends/coming-soon tabs
   const dateNav = document.querySelector('.date-nav');
   const tabBar = document.getElementById('tab-bar');
-  if (view === 'trends') {
+  const hideDateControls = view === 'trends' || view === 'slack' || view === 'notion';
+  if (hideDateControls) {
     if (dateNav) dateNav.style.display = 'none';
     if (tabBar) tabBar.style.display = 'none';
   } else {
     if (dateNav) dateNav.style.display = '';
     if (tabBar) tabBar.style.display = '';
   }
-  // Load data
-  loadViewData(view);
+  // Load data (skip for coming-soon views)
+  if (view !== 'slack' && view !== 'notion') loadViewData(view);
 }
 
 function loadViewData(view) {
@@ -1658,6 +1659,12 @@ async function exchangeSlackToken() {
 function renderSettingsPrefs() {
   if (!state.config) { dom.settingsPrefs.innerHTML = ''; return; }
   const c = state.config;
+  const wh = c.working_hours || {};
+  const workingDays = wh.working_days || ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const allDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const dayCheckboxes = allDays.map(d =>
+    `<label class="pref-day-label"><input type="checkbox" class="pref-day-cb" value="${d}"${workingDays.includes(d) ? ' checked' : ''}> ${d}</label>`
+  ).join('');
   dom.settingsPrefs.innerHTML = `
     <div class="pref-row">
       <label class="pref-label">Sync interval (min)</label>
@@ -1680,39 +1687,59 @@ function renderSettingsPrefs() {
       <input class="pref-input" type="text" id="pref-ignored-channels" value="${escapeAttr((c.slack?.ignored_channels || []).join(', '))}" placeholder="github-prs, graphite-*">
       <div class="pref-hint">Comma-separated, supports glob patterns</div>
     </div>
+    <div class="pref-section-divider">Working Hours</div>
+    <div class="pref-row">
+      <label class="pref-label">Work start</label>
+      <input class="pref-input pref-input-time" type="time" id="pref-work-start" value="${escapeAttr(wh.work_start || '09:00')}">
+    </div>
+    <div class="pref-row">
+      <label class="pref-label">Work end</label>
+      <input class="pref-input pref-input-time" type="time" id="pref-work-end" value="${escapeAttr(wh.work_end || '17:00')}">
+    </div>
+    <div class="pref-row pref-row-days">
+      <label class="pref-label">Working days</label>
+      <div class="pref-days">${dayCheckboxes}</div>
+    </div>
+    <div class="pref-row">
+      <label class="pref-label">Timezone</label>
+      <input class="pref-input" type="text" id="pref-timezone" value="${escapeAttr(wh.timezone || 'UTC')}" placeholder="UTC, Europe/London, America/New_York…">
+      <div class="pref-hint">IANA timezone name</div>
+    </div>
     <div class="pref-save-row">
-      <button class="btn btn-highlight" id="pref-save-btn">Save Preferences</button>
+      <button class="btn" id="pref-save-btn">Save Preferences</button>
     </div>
     <div style="margin-top:20px;padding-top:16px;border-top:1px solid var(--border)">
       <div style="font-size:12px;color:var(--text-dim);margin-bottom:8px">Clear all synced activities, LLM summaries, and sync cursors. Tokens are kept.</div>
-      <button class="btn" id="pref-clear-cache-btn" style="background:var(--highlight)">Clear Cached Data</button>
+      <button class="btn btn-danger" id="pref-clear-cache-btn">Clear Cached Data</button>
     </div>
   `;
   document.getElementById('pref-save-btn')?.addEventListener('click', savePreferences);
   const clearBtn = document.getElementById('pref-clear-cache-btn');
   if (clearBtn) {
-    clearBtn.addEventListener('click', async () => {
-      console.log('clear cache button clicked');
-      clearBtn.disabled = true;
-      clearBtn.textContent = 'Clearing...';
-      try {
-        await invoke('clear_cache');
-        state.digest = null;
-        state.llmCache = {};
-        state.standupCache = {};
-        clearBtn.textContent = 'Cleared!';
-        showToast('Cache cleared! Hit Sync to re-fetch.', 'success');
-      } catch (err) {
-        console.error('clear_cache failed:', err);
-        clearBtn.textContent = 'Clear Cached Data';
-        showToast(`Failed to clear cache: ${err}`, 'error');
-      } finally {
-        clearBtn.disabled = false;
-        setTimeout(() => { clearBtn.textContent = 'Clear Cached Data'; }, 2000);
-      }
+    clearBtn.addEventListener('click', () => {
+      showConfirmDialog(
+        'Clear Cached Data',
+        'This will remove all synced activities, LLM summaries, and sync cursors. Your API tokens will be kept. Are you sure?',
+        async () => {
+          clearBtn.disabled = true;
+          clearBtn.textContent = 'Clearing...';
+          try {
+            await invoke('clear_cache');
+            state.digest = null;
+            state.llmCache = {};
+            state.standupCache = {};
+            clearBtn.textContent = 'Cleared!';
+            showToast('Cache cleared! Hit Sync to re-fetch.', 'success');
+          } catch (err) {
+            console.error('clear_cache failed:', err);
+            showToast(`Failed to clear cache: ${err}`, 'error');
+          } finally {
+            clearBtn.disabled = false;
+            setTimeout(() => { clearBtn.textContent = 'Clear Cached Data'; }, 2000);
+          }
+        }
+      );
     });
-  } else {
-    console.warn('pref-clear-cache-btn not found');
   }
 }
 
@@ -1726,6 +1753,13 @@ async function savePreferences() {
   state.config.slack.user_id = slackUserId || null;
   const ignoredStr = document.getElementById('pref-ignored-channels')?.value || '';
   state.config.slack.ignored_channels = ignoredStr.split(',').map(s => s.trim()).filter(Boolean);
+  // Working hours
+  if (!state.config.working_hours) state.config.working_hours = {};
+  state.config.working_hours.work_start = document.getElementById('pref-work-start')?.value || '09:00';
+  state.config.working_hours.work_end = document.getElementById('pref-work-end')?.value || '17:00';
+  state.config.working_hours.timezone = document.getElementById('pref-timezone')?.value?.trim() || 'UTC';
+  const checkedDays = [...document.querySelectorAll('.pref-day-cb:checked')].map(cb => cb.value);
+  state.config.working_hours.working_days = checkedDays;
   try {
     await invoke('update_config', { config: state.config });
     showToast('Preferences saved!', 'success');
@@ -1789,6 +1823,27 @@ function renderMarkdown(text) {
 // ===== Toast =====
 
 let toastTimer = null;
+
+function showConfirmDialog(title, message, onConfirm) {
+  const overlay = document.getElementById('confirm-overlay');
+  document.getElementById('confirm-title').textContent = title;
+  document.getElementById('confirm-message').textContent = message;
+  overlay.style.display = '';
+  const okBtn = document.getElementById('confirm-ok');
+  const cancelBtn = document.getElementById('confirm-cancel');
+  const close = () => { overlay.style.display = 'none'; };
+  const handleOk = () => { close(); onConfirm(); cleanup(); };
+  const handleCancel = () => { close(); cleanup(); };
+  const handleOverlay = (e) => { if (e.target === overlay) { close(); cleanup(); } };
+  function cleanup() {
+    okBtn.removeEventListener('click', handleOk);
+    cancelBtn.removeEventListener('click', handleCancel);
+    overlay.removeEventListener('click', handleOverlay);
+  }
+  okBtn.addEventListener('click', handleOk);
+  cancelBtn.addEventListener('click', handleCancel);
+  overlay.addEventListener('click', handleOverlay);
+}
 
 function showToast(message, type = "info") {
   if (toastTimer) clearTimeout(toastTimer);

--- a/ui/index.html
+++ b/ui/index.html
@@ -16,7 +16,8 @@
         <button class="nav-tab active" data-view="overview">Overview</button>
         <button class="nav-tab" data-view="github"><svg class="nav-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> GitHub</button>
         <button class="nav-tab" data-view="linear"><svg class="nav-icon" width="16" height="16" viewBox="0 0 100 100" fill="currentColor"><path d="M3.35 58.76C1.21 56.61 0 53.7 0 50.66V7a7 7 0 0 1 7-7h43.66c3.04 0 5.95 1.21 8.09 3.35l37.9 37.9a11 11 0 0 1 0 15.51l-39.9 39.89a11 11 0 0 1-15.5 0L3.35 58.76Z"/></svg> Linear</button>
-        <!-- Slack disabled — requires full OAuth -->
+        <button class="nav-tab" data-view="slack"><svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg> Slack</button>
+        <button class="nav-tab" data-view="notion"><svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.14c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.986c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z"/></svg> Notion</button>
         <button class="nav-tab" data-view="trends"><svg class="nav-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M1 13L5 8l3 3 7-9"/></svg> Trends</button>
       </nav>
     </div>
@@ -286,23 +287,57 @@
 
     <!-- View: Slack -->
     <section id="view-slack" class="view-section" style="display:none">
-      <div class="source-view">
-        <div class="source-stats-row" id="slack-stats"></div>
-        <!-- Channel breakdown cards -->
-        <div id="slack-channels" class="slack-channels-grid"></div>
-        <!-- Message table -->
-        <div class="card">
-          <div class="card-header">
-            <span class="card-label">Messages</span>
-            <span id="slack-message-count" class="activity-count"></span>
+      <div class="coming-soon-view">
+        <div class="coming-soon-content">
+          <svg class="coming-soon-robot" viewBox="0 0 120 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="30" y="40" width="60" height="50" rx="10" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="40" y="52" width="14" height="14" rx="4" fill="var(--highlight)"/>
+            <rect x="66" y="52" width="14" height="14" rx="4" fill="var(--highlight)"/>
+            <rect x="45" y="74" width="30" height="6" rx="3" fill="var(--border)"/>
+            <rect x="50" y="76" width="10" height="2" rx="1" fill="var(--text-dim)"/>
+            <rect x="63" y="76" width="10" height="2" rx="1" fill="var(--text-dim)"/>
+            <rect x="52" y="30" width="16" height="12" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <circle cx="60" cy="28" r="4" fill="var(--highlight)"/>
+            <rect x="10" y="55" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="92" y="55" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="40" y="90" width="12" height="30" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="68" y="90" width="12" height="30" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="36" y="116" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="66" y="116" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+          </svg>
+          <div class="coming-soon-text">
+            <h2>Slack Integration</h2>
+            <p class="coming-soon-badge">Coming Soon</p>
+            <p class="coming-soon-desc">Full Slack integration with OAuth support is on its way. You'll be able to view channel activity, messages, and team communications right here.</p>
           </div>
-          <div class="activity-table-wrapper" style="max-height:500px">
-            <table class="activity-table">
-              <thead><tr>
-                <th>Channel</th><th>Message</th><th>Kind</th><th>Time</th>
-              </tr></thead>
-              <tbody id="slack-message-tbody"></tbody>
-            </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- View: Notion -->
+    <section id="view-notion" class="view-section" style="display:none">
+      <div class="coming-soon-view">
+        <div class="coming-soon-content">
+          <svg class="coming-soon-robot" viewBox="0 0 120 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <rect x="30" y="40" width="60" height="50" rx="10" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="40" y="52" width="14" height="14" rx="4" fill="var(--highlight)"/>
+            <rect x="66" y="52" width="14" height="14" rx="4" fill="var(--highlight)"/>
+            <rect x="45" y="74" width="30" height="6" rx="3" fill="var(--border)"/>
+            <rect x="50" y="76" width="10" height="2" rx="1" fill="var(--text-dim)"/>
+            <rect x="63" y="76" width="10" height="2" rx="1" fill="var(--text-dim)"/>
+            <rect x="52" y="30" width="16" height="12" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <circle cx="60" cy="28" r="4" fill="var(--highlight)"/>
+            <rect x="10" y="55" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="92" y="55" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="40" y="90" width="12" height="30" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="68" y="90" width="12" height="30" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="36" y="116" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+            <rect x="66" y="116" width="18" height="8" rx="4" fill="var(--accent)" stroke="var(--border)" stroke-width="2"/>
+          </svg>
+          <div class="coming-soon-text">
+            <h2>Notion Integration</h2>
+            <p class="coming-soon-badge">Coming Soon</p>
+            <p class="coming-soon-desc">Connect your Notion workspace to see pages, databases, and tasks alongside your other activity. Notes and docs will be part of your daily recap.</p>
           </div>
         </div>
       </div>
@@ -445,6 +480,20 @@
           <h3 class="settings-section-title">Preferences</h3>
           <div id="settings-prefs"></div>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Confirm Dialog -->
+  <div id="confirm-overlay" class="modal-overlay" style="display:none">
+    <div class="modal confirm-modal">
+      <div class="modal-header">
+        <h2 id="confirm-title">Confirm</h2>
+      </div>
+      <p id="confirm-message" style="color:var(--text-dim);font-size:13px;margin-bottom:20px;line-height:1.5"></p>
+      <div class="modal-footer">
+        <button id="confirm-cancel" class="btn btn-secondary" style="margin-right:8px">Cancel</button>
+        <button id="confirm-ok" class="btn btn-danger">Confirm</button>
       </div>
     </div>
   </div>

--- a/ui/style.css
+++ b/ui/style.css
@@ -1802,6 +1802,129 @@ body {
   margin: 2px 0;
 }
 
+/* ===== Danger Button ===== */
+.btn-danger {
+  background: var(--highlight);
+}
+
+.btn-danger:hover {
+  background: #d63a54;
+}
+
+/* ===== Secondary Button ===== */
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-dim);
+}
+
+.btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--text);
+}
+
+/* ===== Confirm Dialog ===== */
+.confirm-modal {
+  width: 400px;
+}
+
+/* ===== Coming Soon View ===== */
+.coming-soon-view {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 40px;
+}
+
+.coming-soon-content {
+  display: flex;
+  align-items: center;
+  gap: 48px;
+  max-width: 640px;
+}
+
+.coming-soon-robot {
+  width: 120px;
+  height: 140px;
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
+.coming-soon-text h2 {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 10px;
+}
+
+.coming-soon-badge {
+  display: inline-block;
+  background: var(--accent);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border-radius: 20px;
+  margin-bottom: 14px;
+}
+
+.coming-soon-desc {
+  font-size: 14px;
+  color: var(--text-dim);
+  line-height: 1.65;
+}
+
+/* ===== Nav tab active colours for new tabs ===== */
+.nav-tab.active[data-view="slack"]  { border-bottom-color: var(--slack); }
+.nav-tab.active[data-view="notion"] { border-bottom-color: var(--notion); }
+
+/* ===== Settings: working hours & new pref styles ===== */
+.pref-section-divider {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 14px 0 6px;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+}
+
+.pref-input-time {
+  width: 120px;
+  color-scheme: dark;
+}
+
+.pref-row-days {
+  align-items: flex-start;
+  padding-top: 6px;
+}
+
+.pref-days {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pref-day-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--text-dim);
+  cursor: pointer;
+  user-select: none;
+}
+
+.pref-day-label input[type="checkbox"] {
+  accent-color: var(--accent);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+
 /* ===== Utility ===== */
 .hidden {
   display: none !important;


### PR DESCRIPTION
## Summary
This PR adds working hours configuration support, placeholder "coming soon" views for Slack and Notion integrations, and a confirmation dialog component for destructive actions.

## Key Changes

**Working Hours Configuration**
- Added `WorkingHoursConfig` struct to store work start/end times, working days, and timezone
- New settings UI in preferences panel with time inputs, day-of-week checkboxes, and timezone field
- Configuration is persisted and loaded from the app config

**Coming Soon Views**
- Replaced Slack view with a "coming soon" placeholder featuring a robot SVG illustration
- Added Notion view with similar coming-soon placeholder
- Both views hide date navigation and period tabs (like Trends view)
- Skip data loading for these placeholder views

**Confirmation Dialog**
- New `showConfirmDialog()` function for confirming destructive actions
- Styled modal with title, message, and Cancel/Confirm buttons
- Integrated with "Clear Cached Data" button to require confirmation before clearing cache
- Supports overlay click-to-close and proper event listener cleanup

**UI Improvements**
- New button styles: `.btn-danger` (red highlight) and `.btn-secondary` (subtle white background)
- New CSS classes for coming-soon view layout and styling
- Settings preferences section divider for visual organization
- Time input styling with `color-scheme: dark`

**Navigation Updates**
- Slack and Notion tabs now visible in navigation bar with SVG icons
- Active tab border colors use integration-specific color variables

## Implementation Details
- Working hours data is stored in `state.config.working_hours` and synced via `update_config` invoke
- Coming-soon views are identified by checking view name in `switchView()` to skip data loading
- Confirm dialog uses event delegation and cleanup pattern to prevent memory leaks
- All new UI elements use existing CSS variables for theme consistency

https://claude.ai/code/session_018u2oJgrmyS5dmT2rrgBdy3