### PR TITLE
feat(ui): show update-available banner in main view

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -42,6 +42,7 @@ async function checkForUpdates(silent = true) {
     state.updateStatus = 'error';
     state.updateError = String(e);
   }
+  renderUpdateBanner();
 }
 
 async function installUpdate() {
@@ -53,6 +54,32 @@ async function installUpdate() {
   } catch (e) {
     showToast(`Update failed: ${e}`, 'error');
   }
+}
+
+// ===== Update Banner (main view) =====
+
+function renderUpdateBanner() {
+  const banner = document.getElementById('update-banner');
+  if (!banner) return;
+
+  if (state.updateStatus === 'available' && state.updateVersion && !state.updateBannerDismissed) {
+    document.getElementById('update-banner-text').textContent =
+      `v${state.updateVersion} available`;
+    banner.style.display = '';
+  } else {
+    banner.style.display = 'none';
+  }
+}
+
+function dismissUpdateBanner() {
+  state.updateBannerDismissed = true;
+  const banner = document.getElementById('update-banner');
+  if (banner) banner.style.display = 'none';
+}
+
+function bindUpdateBannerEvents() {
+  document.getElementById('update-banner-dismiss')?.addEventListener('click', dismissUpdateBanner);
+  document.getElementById('update-banner-install')?.addEventListener('click', installUpdate);
 }
 
 // ===== State =====
@@ -81,6 +108,7 @@ const state = {
   gridLayout: null,
   gridEditMode: false,
   lastSyncTime: null,
+  updateBannerDismissed: false,
 };
 
 // ===== Grid Layout System =====
@@ -680,6 +708,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   renderDate();
   bindEvents();
   initCollapsibleCards();
+  bindUpdateBannerEvents();
   await refreshAuthStatus();
   // Load config first so grid layout can read it
   try {
@@ -845,6 +874,8 @@ function bindEvents() {
 
 function switchView(view) {
   state.activeView = view;
+  // Dismiss update banner on navigation
+  dismissUpdateBanner();
   // Exit edit mode if leaving overview
   if (view !== 'overview' && state.gridEditMode) {
     toggleEditMode();

--- a/ui/index.html
+++ b/ui/index.html
@@ -53,6 +53,16 @@
     <button id="auth-banner-btn" class="btn btn-small">Settings</button>
   </div>
 
+  <!-- Update Available Banner -->
+  <div id="update-banner" class="update-banner" style="display:none">
+    <div class="update-banner-content">
+      <span class="update-banner-dot"></span>
+      <span id="update-banner-text" class="update-banner-text"></span>
+      <button id="update-banner-install" class="btn btn-small btn-highlight">Install</button>
+    </div>
+    <button id="update-banner-dismiss" class="update-banner-dismiss" title="Dismiss">&times;</button>
+  </div>
+
   <!-- Main Content Area -->
   <main id="main" class="main">
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -327,6 +327,59 @@ body {
   font-weight: 500;
 }
 
+/* ===== Update Available Banner ===== */
+.update-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 24px;
+  background: color-mix(in srgb, var(--status-open) 8%, var(--bg));
+  border-bottom: 1px solid color-mix(in srgb, var(--status-open) 25%, var(--border));
+  flex-shrink: 0;
+  animation: update-banner-slide-in 0.3s ease-out;
+}
+
+@keyframes update-banner-slide-in {
+  from { opacity: 0; transform: translateY(-100%); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.update-banner-content {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.update-banner-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--status-open);
+  box-shadow: 0 0 6px var(--status-open);
+  flex-shrink: 0;
+}
+
+.update-banner-text {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.update-banner-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+
+.update-banner-dismiss:hover {
+  color: var(--text);
+}
+
 .settings-auth-warning {
   padding: 8px 12px;
   margin-bottom: 12px;


### PR DESCRIPTION
## Problem

The update status is only visible inside settings. Users may not notice available updates since they have to open the settings panel to see them.

## Solution

- Added an update banner element between the auth-banner and main content with status dot, version text, "Install" button, and dismiss button
- `renderUpdateBanner()` shows the banner when `state.updateStatus === 'available'` and not dismissed
- Auto-dismisses on view navigation via `switchView()`
- Dismiss button sets `state.updateBannerDismissed = true`
- Install button reuses existing `installUpdate()` function
- Styled with subtle tinted background using `color-mix()` and slide-in animation

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)