### PR TITLE
feat(ui): render GitHub label colors from API

### DIFF
--- a/src/integrations/github.rs
+++ b/src/integrations/github.rs
@@ -801,6 +801,12 @@ fn parse_issues_event(
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, serde::Serialize)]
+pub struct GitHubLabel {
+    pub name: String,
+    pub color: String, // hex color without '#', e.g. "d73a4a"
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct OpenPr {
     pub number: u64,
     pub title: String,
@@ -809,7 +815,7 @@ pub struct OpenPr {
     pub state: String,       // "open" or "draft"
     pub created_at: String,
     pub updated_at: String,
-    pub labels: Vec<String>,
+    pub labels: Vec<GitHubLabel>,
     pub review_status: String, // "approved", "changes_requested", "review_required", ""
     pub additions: u64,
     pub deletions: u64,
@@ -884,11 +890,15 @@ pub async fn fetch_open_prs(config: &crate::config::AppConfig) -> Result<Vec<Ope
         let updated_at = item["updated_at"].as_str().unwrap_or_default().to_string();
         let is_draft = item["draft"].as_bool().unwrap_or(false);
 
-        let labels: Vec<String> = item["labels"]
+        let labels: Vec<GitHubLabel> = item["labels"]
             .as_array()
             .unwrap_or(&empty_vec)
             .iter()
-            .filter_map(|l| l["name"].as_str().map(|s| s.to_string()))
+            .filter_map(|l| {
+                let name = l["name"].as_str()?.to_string();
+                let color = l["color"].as_str().unwrap_or("ededed").to_string();
+                Some(GitHubLabel { name, color })
+            })
             .collect();
 
         let (cc_type, cc_scope) = parse_conventional_commit(&title);
@@ -926,7 +936,7 @@ pub struct GitHubIssue {
     pub state: String,
     pub created_at: String,
     pub updated_at: String,
-    pub labels: Vec<String>,
+    pub labels: Vec<GitHubLabel>,
     pub comments: u64,
 }
 
@@ -1002,11 +1012,15 @@ pub async fn fetch_github_issues(config: &crate::config::AppConfig) -> Result<Ve
         let updated_at = item["updated_at"].as_str().unwrap_or_default().to_string();
         let comments = item["comments"].as_u64().unwrap_or(0);
 
-        let labels: Vec<String> = item["labels"]
+        let labels: Vec<GitHubLabel> = item["labels"]
             .as_array()
             .unwrap_or(&empty_vec)
             .iter()
-            .filter_map(|l| l["name"].as_str().map(|s| s.to_string()))
+            .filter_map(|l| {
+                let name = l["name"].as_str()?.to_string();
+                let color = l["color"].as_str().unwrap_or("ededed").to_string();
+                Some(GitHubLabel { name, color })
+            })
             .collect();
 
         issues.push(GitHubIssue {

--- a/ui/app.js
+++ b/ui/app.js
@@ -1493,7 +1493,11 @@ async function fetchGitHubIssues() {
     }
     dom.githubIssueTbody.innerHTML = issues.map(issue => {
       const labelsHtml = issue.labels.length
-        ? issue.labels.map(l => `<span class="cc-tag">${escapeHtml(l)}</span>`).join(' ')
+        ? issue.labels.map(l => {
+            const bg = `#${l.color}`;
+            const textColor = labelContrastColor(l.color);
+            return `<span class="cc-tag gh-label" style="background:${bg};color:${textColor}">${escapeHtml(l.name)}</span>`;
+          }).join(' ')
         : '';
       return `<tr>
         <td><span class="kind-badge kind-open">Open</span> ${labelsHtml}</td>
@@ -2781,6 +2785,17 @@ function renderBurnoutChart(burnout) {
 }
 
 // ===== Utilities =====
+
+/** Return '#fff' or '#000' depending on background luminance for readable contrast. */
+function labelContrastColor(hexColor) {
+  const hex = hexColor.replace(/^#/, '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  // W3C relative luminance formula
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#000' : '#fff';
+}
 
 function escapeHtml(str) {
   if (!str) return "";

--- a/ui/style.css
+++ b/ui/style.css
@@ -1562,6 +1562,8 @@ body {
   white-space: nowrap;
 }
 
+.cc-tag.gh-label { text-transform: none; }
+
 .cc-feat { background: color-mix(in srgb, var(--status-completed) 20%, transparent); color: var(--status-completed); }
 .cc-fix { background: color-mix(in srgb, var(--status-closed) 20%, transparent); color: var(--status-closed); }
 .cc-perf { background: color-mix(in srgb, var(--status-review) 20%, transparent); color: var(--status-review); }


### PR DESCRIPTION
## Problem

GitHub labels have a `color` field in the API response but are rendered with generic `cc-tag` styling. All labels look the same regardless of their GitHub color.

## Solution

- Added `GitHubLabel` struct with `name` and `color` fields in `github.rs`
- Changed `labels` field from `Vec<String>` to `Vec<GitHubLabel>` in both `OpenPr` and `GitHubIssue` structs
- Updated label parsing to extract `color` from API response (defaults to `"ededed"`)
- Added `labelContrastColor(hexColor)` utility using W3C perceived luminance to return `#000` or `#fff`
- Labels render with actual GitHub background color and appropriate text contrast
- Added `.cc-tag.gh-label` CSS to preserve original label casing

`cargo check` clean.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)