### PR TITLE
feat(ui): add collapsible card sections to GitHub view

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -369,6 +369,88 @@ function resetGridLayout() {
   showToast("Layout reset to defaults", "success");
 }
 
+// ===== Collapsible Card Sections =====
+
+const COLLAPSED_CARDS_KEY = 'recap_collapsed_cards';
+
+function getCollapsedCards() {
+  try {
+    const stored = localStorage.getItem(COLLAPSED_CARDS_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function setCardCollapsed(cardId, collapsed) {
+  const collapsedCards = getCollapsedCards();
+  if (collapsed) {
+    collapsedCards[cardId] = true;
+  } else {
+    delete collapsedCards[cardId];
+  }
+  try {
+    localStorage.setItem(COLLAPSED_CARDS_KEY, JSON.stringify(collapsedCards));
+  } catch {}
+}
+
+function toggleCardCollapse(card) {
+  const cardId = card.dataset.cardId;
+  if (!cardId) return;
+  const isCollapsed = card.classList.toggle('collapsed');
+  setCardCollapsed(cardId, isCollapsed);
+}
+
+/**
+ * Initializes collapsible behavior on all cards with data-card-id.
+ * Wraps non-header children in a .card-collapsible-content div and
+ * restores persisted collapsed state from localStorage.
+ */
+function initCollapsibleCards() {
+  const collapsedState = getCollapsedCards();
+  const cards = document.querySelectorAll('.card[data-card-id]');
+
+  cards.forEach(card => {
+    const cardId = card.dataset.cardId;
+
+    // Avoid re-initializing if already wrapped
+    if (card.querySelector('.card-collapsible-content')) return;
+
+    // Collect all children after the card-header into a wrapper
+    const header = card.querySelector('.card-header');
+    if (!header) return;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'card-collapsible-content';
+
+    // Move all siblings after header into the wrapper
+    const children = [...card.children];
+    let afterHeader = false;
+    for (const child of children) {
+      if (child === header) {
+        afterHeader = true;
+        continue;
+      }
+      if (afterHeader) {
+        wrapper.appendChild(child);
+      }
+    }
+    card.appendChild(wrapper);
+
+    // Restore collapsed state
+    if (collapsedState[cardId]) {
+      card.classList.add('collapsed');
+    }
+
+    // Click on the header toggles collapse
+    header.addEventListener('click', (e) => {
+      // Don't toggle if clicking a link, button (other than the toggle), or input inside header
+      if (e.target.closest('a, input, select')) return;
+      toggleCardCollapse(card);
+    });
+  });
+}
+
 // ===== Constants =====
 
 const SOURCE_META = {
@@ -553,6 +635,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   initKindColors();
   renderDate();
   bindEvents();
+  initCollapsibleCards();
   await refreshAuthStatus();
   // Load config first so grid layout can read it
   try {

--- a/ui/index.html
+++ b/ui/index.html
@@ -182,9 +182,14 @@
         <div class="source-stats-row" id="github-stats"></div>
 
         <!-- PR Table -->
-        <div class="card">
-          <div class="card-header">
-            <span class="card-label">Pull Requests</span>
+        <div class="card" data-card-id="github-prs">
+          <div class="card-header card-header-collapsible">
+            <div class="card-header-left">
+              <button class="card-collapse-toggle" aria-label="Toggle section">
+                <svg class="collapse-chevron" width="12" height="12" viewBox="0 0 12 12"><path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <span class="card-label">Pull Requests</span>
+            </div>
             <span id="github-pr-count" class="activity-count"></span>
           </div>
           <div id="github-cc-filters" class="cc-filter-bar"></div>
@@ -199,9 +204,14 @@
         </div>
 
         <!-- Commits Table -->
-        <div class="card">
-          <div class="card-header">
-            <span class="card-label">Commits</span>
+        <div class="card" data-card-id="github-commits">
+          <div class="card-header card-header-collapsible">
+            <div class="card-header-left">
+              <button class="card-collapse-toggle" aria-label="Toggle section">
+                <svg class="collapse-chevron" width="12" height="12" viewBox="0 0 12 12"><path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <span class="card-label">Commits</span>
+            </div>
             <span id="github-commit-count" class="activity-count"></span>
           </div>
           <div class="activity-table-wrapper">
@@ -215,9 +225,14 @@
         </div>
 
         <!-- Reviews Table -->
-        <div class="card">
-          <div class="card-header">
-            <span class="card-label">Reviews</span>
+        <div class="card" data-card-id="github-reviews">
+          <div class="card-header card-header-collapsible">
+            <div class="card-header-left">
+              <button class="card-collapse-toggle" aria-label="Toggle section">
+                <svg class="collapse-chevron" width="12" height="12" viewBox="0 0 12 12"><path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <span class="card-label">Reviews</span>
+            </div>
             <span id="github-review-count" class="activity-count"></span>
           </div>
           <div class="activity-table-wrapper">
@@ -231,9 +246,14 @@
         </div>
 
         <!-- Issues (assigned to user) -->
-        <div class="card">
-          <div class="card-header">
-            <span class="card-label">Issues</span>
+        <div class="card" data-card-id="github-issues">
+          <div class="card-header card-header-collapsible">
+            <div class="card-header-left">
+              <button class="card-collapse-toggle" aria-label="Toggle section">
+                <svg class="collapse-chevron" width="12" height="12" viewBox="0 0 12 12"><path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <span class="card-label">Issues</span>
+            </div>
             <span id="github-issue-count" class="activity-count"></span>
           </div>
           <div class="activity-table-wrapper" style="max-height:600px">
@@ -247,9 +267,14 @@
         </div>
 
         <!-- Open / Draft PRs -->
-        <div class="card">
-          <div class="card-header">
-            <span class="card-label">Open PRs</span>
+        <div class="card" data-card-id="github-open-prs">
+          <div class="card-header card-header-collapsible">
+            <div class="card-header-left">
+              <button class="card-collapse-toggle" aria-label="Toggle section">
+                <svg class="collapse-chevron" width="12" height="12" viewBox="0 0 12 12"><path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <span class="card-label">Open PRs</span>
+            </div>
             <span id="github-open-pr-count" class="activity-count"></span>
           </div>
           <div class="activity-table-wrapper" style="max-height:600px">

--- a/ui/style.css
+++ b/ui/style.css
@@ -636,6 +636,65 @@ body {
   color: var(--text-dim);
 }
 
+/* ===== Collapsible Card Sections ===== */
+
+.card-header-collapsible {
+  cursor: pointer;
+  user-select: none;
+}
+
+.card-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.card-collapse-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+  flex-shrink: 0;
+}
+
+.card-collapse-toggle:hover {
+  color: var(--text-dim);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.collapse-chevron {
+  transition: transform 0.2s ease;
+  transform: rotate(90deg);
+}
+
+.card.collapsed .collapse-chevron {
+  transform: rotate(0deg);
+}
+
+.card-collapsible-content {
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.2s ease;
+  max-height: 2000px;
+  opacity: 1;
+}
+
+.card.collapsed .card-collapsible-content {
+  max-height: 0;
+  opacity: 0;
+}
+
+.card.collapsed .card-header-collapsible {
+  margin-bottom: 0;
+}
+
 /* Full width card spans all columns (fallback) */
 .card-full-width {
   grid-column: 1 / -1;


### PR DESCRIPTION
## Problem

The GitHub view has 5+ cards (stats, PRs, commits, reviews, issues, open PRs) and the screen gets crowded. Users can't collapse sections they don't need to see.

## Solution

- Added `data-card-id` attributes to all 5 GitHub view cards for unique identification
- Added `card-header-collapsible` class with chevron SVG icon that rotates on toggle
- `toggleCardCollapse()` adds/removes `.collapsed` class with smooth `max-height`/`opacity` transitions
- Collapsed state persisted in localStorage (`recap_collapsed_cards`) — survives reloads without needing Rust config changes
- `initCollapsibleCards()` wraps card bodies in `.card-collapsible-content` divs at runtime and restores persisted state
- Click handlers guard against triggering on link/input clicks within headers

Extensible to other views via `data-card-id` + `card-header-collapsible` attributes.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)