### PR TITLE
fix: burnout pipeline with timezone-aware working hours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2791,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
@@ -2923,6 +2942,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -3335,6 +3363,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "chrono-tz",
  "dirs 5.0.1",
  "glob-match",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use chrono::{NaiveDate, NaiveTime, TimeZone, Utc};
+use chrono::{Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 use serde::Serialize;
 use tauri::State;
 
 use crate::auth::{AuthManager, AuthStatus};
 use crate::config::AppConfig;
-use crate::db::{get_activities_for_range, get_cached_summary, set_cached_summary,
+use crate::db::{get_activities_for_range, get_activities_for_range_unlimited, get_cached_summary, set_cached_summary,
     invalidate_all_summaries,
     query_weekly_velocity, query_activity_heatmap, query_cycle_times,
-    query_project_distribution, query_off_hours_ratio, query_message_volume,
+    query_project_distribution, query_message_volume,
     query_daily_vectors, query_dow_project};
 use crate::db::Database;
 use crate::digest::build_digest;
@@ -740,18 +740,116 @@ pub fn naive_bayes_predict(
     probs
 }
 
+fn parse_hhmm_or_default(value: &str, default_h: u32, default_m: u32) -> NaiveTime {
+    let mut parts = value.splitn(2, ':');
+    let hour = parts
+        .next()
+        .and_then(|h| h.parse::<u32>().ok())
+        .unwrap_or(default_h);
+    let minute = parts
+        .next()
+        .and_then(|m| m.parse::<u32>().ok())
+        .unwrap_or(default_m);
+    NaiveTime::from_hms_opt(hour.min(23), minute.min(59), 0)
+        .unwrap_or_else(|| NaiveTime::from_hms_opt(default_h, default_m, 0).expect("valid default"))
+}
+
+fn parse_working_day(day: &str) -> Option<Weekday> {
+    let normalized = day.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "mon" | "monday" => Some(Weekday::Mon),
+        "tue" | "tues" | "tuesday" => Some(Weekday::Tue),
+        "wed" | "wednesday" => Some(Weekday::Wed),
+        "thu" | "thur" | "thurs" | "thursday" => Some(Weekday::Thu),
+        "fri" | "friday" => Some(Weekday::Fri),
+        "sat" | "saturday" => Some(Weekday::Sat),
+        "sun" | "sunday" => Some(Weekday::Sun),
+        _ => None,
+    }
+}
+
+fn is_within_work_window(time: NaiveTime, start: NaiveTime, end: NaiveTime) -> bool {
+    if start < end {
+        time >= start && time < end
+    } else if start > end {
+        // Overnight shift window, e.g. 22:00-06:00.
+        time >= start || time < end
+    } else {
+        // start == end means full-day window.
+        true
+    }
+}
+
+pub fn build_off_hours_rows(
+    activities: &[Activity],
+    working_hours: &crate::config::WorkingHoursConfig,
+) -> Vec<(String, i64, i64)> {
+    let timezone_name = working_hours.timezone.trim();
+    let timezone = timezone_name
+        .parse::<chrono_tz::Tz>()
+        .unwrap_or_else(|_| {
+            tracing::warn!(
+                "invalid working-hours timezone '{}', falling back to UTC",
+                timezone_name
+            );
+            chrono_tz::UTC
+        });
+
+    let mut working_days: std::collections::HashSet<Weekday> = working_hours
+        .working_days
+        .iter()
+        .filter_map(|d| parse_working_day(d))
+        .collect();
+    if working_days.is_empty() {
+        working_days = [
+            Weekday::Mon,
+            Weekday::Tue,
+            Weekday::Wed,
+            Weekday::Thu,
+            Weekday::Fri,
+        ]
+        .into_iter()
+        .collect();
+    }
+
+    let work_start = parse_hhmm_or_default(&working_hours.work_start, 9, 0);
+    let work_end = parse_hhmm_or_default(&working_hours.work_end, 17, 0);
+
+    let mut week_counts: std::collections::BTreeMap<String, (i64, i64)> = std::collections::BTreeMap::new();
+    for activity in activities {
+        let local_dt = activity.occurred_at.with_timezone(&timezone);
+        let week = local_dt.format("%Y-W%W").to_string();
+        let entry = week_counts.entry(week).or_insert((0, 0));
+        entry.0 += 1;
+
+        let is_working_day = working_days.contains(&local_dt.weekday());
+        let in_work_window = is_within_work_window(local_dt.time(), work_start, work_end);
+        if !is_working_day || !in_work_window {
+            entry.1 += 1;
+        }
+    }
+
+    week_counts
+        .into_iter()
+        .map(|(week, (total, off_hours))| (week, total, off_hours))
+        .collect()
+}
+
 #[tauri::command]
 pub async fn get_trends_data(
     state: State<'_, AppState>,
 ) -> Result<TrendsData, String> {
     let since = Utc::now() - chrono::Duration::weeks(12);
+    let now = Utc::now();
+    let config = state.config.lock().map_err(|e| e.to_string())?.clone();
 
     // Run all queries
     let velocity_rows = query_weekly_velocity(&state.db, since).map_err(|e| e.to_string())?;
     let heatmap_rows = query_activity_heatmap(&state.db, since).map_err(|e| e.to_string())?;
     let cycle_rows = query_cycle_times(&state.db, since).map_err(|e| e.to_string())?;
     let project_rows = query_project_distribution(&state.db, since).map_err(|e| e.to_string())?;
-    let offhours_rows = query_off_hours_ratio(&state.db, since).map_err(|e| e.to_string())?;
+    let burnout_activities = get_activities_for_range_unlimited(&state.db, since, now).map_err(|e| e.to_string())?;
+    let offhours_rows = build_off_hours_rows(&burnout_activities, &config.working_hours);
     let msg_rows = query_message_volume(&state.db, since).map_err(|e| e.to_string())?;
     let daily_rows = query_daily_vectors(&state.db, since).map_err(|e| e.to_string())?;
     let dow_proj_rows = query_dow_project(&state.db, since).map_err(|e| e.to_string())?;

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -53,6 +53,26 @@ pub fn get_activities_for_range(
     rows.collect()
 }
 
+/// Returns all activities whose `occurred_at` falls within [start, end), ordered by occurred_at DESC.
+/// Used by rollups that need complete aggregates (for example burnout over multiple weeks).
+pub fn get_activities_for_range_unlimited(
+    db: &Database,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+) -> rusqlite::Result<Vec<Activity>> {
+    let conn = db.conn.lock().unwrap();
+    let mut stmt = conn.prepare(
+        "SELECT id, source, source_id, kind, title, description, url, project, occurred_at, metadata, synced_at
+         FROM activities
+         WHERE occurred_at >= ?1 AND occurred_at < ?2
+         ORDER BY occurred_at DESC",
+    )?;
+
+    let rows = stmt.query_map(params![start.to_rfc3339(), end.to_rfc3339()], row_to_activity)?;
+
+    rows.collect()
+}
+
 /// Returns activities for a specific source within a time range, ordered by occurred_at DESC.
 /// Limited to ACTIVITY_LIMIT rows to cap memory usage.
 pub fn get_activities_by_source(

--- a/tests/test_ml_helpers.rs
+++ b/tests/test_ml_helpers.rs
@@ -1,6 +1,10 @@
 use recap::commands::{
-    linear_regression, holt_winters_forecast, detect_anomalies, kmeans, naive_bayes_predict,
+    build_off_hours_rows, detect_anomalies, holt_winters_forecast, kmeans, linear_regression,
+    naive_bayes_predict,
 };
+use recap::config::WorkingHoursConfig;
+use recap::models::{Activity, ActivityKind, Source};
+use chrono::{DateTime, Utc};
 
 // ---------------------------------------------------------------------------
 // linear_regression
@@ -203,4 +207,67 @@ fn naive_bayes_truncates_to_five() {
         .collect();
     let result = naive_bayes_predict(&data, 1);
     assert_eq!(result.len(), 5);
+}
+
+// ---------------------------------------------------------------------------
+// build_off_hours_rows
+// ---------------------------------------------------------------------------
+
+fn test_activity(occurred_at: &str) -> Activity {
+    Activity {
+        id: "test-id".to_string(),
+        source: Source::GitHub,
+        source_id: format!("src-{occurred_at}"),
+        kind: ActivityKind::CommitPushed,
+        title: "test".to_string(),
+        description: None,
+        url: "https://example.com".to_string(),
+        project: Some("proj".to_string()),
+        occurred_at: DateTime::parse_from_rfc3339(occurred_at)
+            .unwrap()
+            .with_timezone(&Utc),
+        metadata: serde_json::Value::Null,
+        synced_at: Utc::now(),
+    }
+}
+
+#[test]
+fn off_hours_counts_weekends_and_after_hours() {
+    let activities = vec![
+        test_activity("2026-03-16T10:00:00Z"), // Monday, in-hours
+        test_activity("2026-03-16T21:00:00Z"), // Monday, after-hours
+        test_activity("2026-03-21T12:00:00Z"), // Saturday
+    ];
+
+    let cfg = WorkingHoursConfig {
+        work_start: "09:00".to_string(),
+        work_end: "17:00".to_string(),
+        working_days: vec!["Mon".to_string(), "Tue".to_string(), "Wed".to_string(), "Thu".to_string(), "Fri".to_string()],
+        timezone: "UTC".to_string(),
+    };
+
+    let rows = build_off_hours_rows(&activities, &cfg);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1, 3); // total
+    assert_eq!(rows[0].2, 2); // off-hours
+}
+
+#[test]
+fn off_hours_respects_timezone_conversion() {
+    let activities = vec![
+        test_activity("2026-01-06T08:30:00Z"), // London 08:30 (off-hours)
+        test_activity("2026-01-06T09:30:00Z"), // London 09:30 (in-hours)
+    ];
+
+    let cfg = WorkingHoursConfig {
+        work_start: "09:00".to_string(),
+        work_end: "17:00".to_string(),
+        working_days: vec!["Mon".to_string(), "Tue".to_string(), "Wed".to_string(), "Thu".to_string(), "Fri".to_string()],
+        timezone: "Europe/London".to_string(),
+    };
+
+    let rows = build_off_hours_rows(&activities, &cfg);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1, 2);
+    assert_eq!(rows[0].2, 1);
 }


### PR DESCRIPTION
## Problem
Burnout trend signals were based on hardcoded UTC thresholds (weekday + hour windows) and did not respect user-configured working hours/timezone. This could misclassify in-hours activity as off-hours (or vice versa), producing misleading burnout trends.

The burnout rollup path also depended on a capped activity query (500 rows), which could undercount older weeks in a 12-week window for active users.

## Solution
- Switched burnout off-hours classification to use configured `working_hours`:
  - `work_start`
  - `work_end`
  - `working_days`
  - `timezone`
- Added robust parsing/fallback behavior for timezone, day names, and HH:MM windows.
- Added a dedicated uncapped range query for burnout aggregation so weekly totals are complete.
- Added tests covering:
  - weekend + after-hours classification
  - timezone-aware classification behavior
- Added `chrono-tz` dependency to support IANA timezone conversion.

## Validation
- `cargo test --quiet`
