### PR TITLE
feat(llm): add work and personal profile modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Built with Rust and Tauri v2 for minimal resource usage (~10MB RAM, no Electron,
 - **Linear Progress** — completed/in-progress/other bar visualization with state filters
 - **AI Daily Briefing** — auto-generated summary via `claude` CLI, grouped by theme not tool
 - **Standup Generator** — "What I Did / What I Will Do" modal with copy-to-clipboard
+- **LLM profile modes** — choose `work` or `personal` framing for AI summaries/trend commentary
 - **Date navigation** — prev/next arrows to browse historical day/week/month data
 - **Background sync** every 5 minutes (configurable) with incremental fetching
 - **SQLite caching** with tiered TTL (5 min hot / 1 hour warm / 24 hour cold)
@@ -127,6 +128,7 @@ cold_minutes = 1440              # Cache TTL for older data (24h)
 [llm]
 enabled = false                  # Set to true for Anthropic API fallback
 # model = "claude-haiku-4-5-20251001"
+# profile = "work"               # "work" or "personal"
 ```
 
 ## Architecture

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,3 +18,4 @@ cold_minutes = 1440
 [llm]
 enabled = false
 # model = "claude-haiku-4-5-20251001"
+# profile = "work"   # "work" or "personal"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -191,6 +191,12 @@ pub async fn clear_cache(state: State<'_, AppState>) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub async fn clear_llm_cache(state: State<'_, AppState>) -> Result<(), String> {
+    invalidate_all_summaries(&state.db);
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn trigger_sync(state: State<'_, AppState>) -> Result<String, String> {
     let db = Arc::clone(&state.db);
     let config = state.config.lock().map_err(|e| e.to_string())?.clone();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -230,7 +230,12 @@ pub async fn get_llm_summary(
 
     // Build a cache key from period + date range.
     let config = state.config.lock().map_err(|e| e.to_string())?.clone();
-    let cache_key = format!("summary:{}:{}", period, start.to_rfc3339());
+    let cache_key = format!(
+        "summary:{}:{}:{}",
+        config.llm.profile,
+        period,
+        start.to_rfc3339()
+    );
     let ttl = config.ttl.warm_minutes;
 
     // Check cache first.
@@ -383,7 +388,7 @@ pub async fn get_standup(
     let today_end = today_start + chrono::Duration::days(1);
 
     let config = state.config.lock().map_err(|e| e.to_string())?.clone();
-    let cache_key = format!("standup:v2:{}", base_date);
+    let cache_key = format!("standup:v3:{}:{}", config.llm.profile, base_date);
     let ttl = config.ttl.warm_minutes;
     if let Some(cached) = get_cached_summary(&state.db, &cache_key, ttl) {
         return Ok(Some(cached));
@@ -433,12 +438,27 @@ pub async fn get_standup(
         .collect::<Vec<_>>()
         .join("\n");
 
+    let profile_instructions = match config.llm.profile {
+        crate::config::LlmProfile::Work => {
+            "Generate a concise daily standup update in markdown with two sections:\n\
+             ## What I Did\n(based on today's activities — what was shipped, reviewed, or completed)\n\
+             ## What I'm Working On\n(based on my open PRs and high-priority Linear tickets)\n\n\
+             Keep each section to 3-5 bullet points. Be specific with ticket/PR numbers.\n\
+             If there's nothing for a section, omit it."
+        }
+        crate::config::LlmProfile::Personal => {
+            "Generate a concise personal dev recap in markdown with two sections:\n\
+             ## What I Did\n(meaningful progress and completed work)\n\
+             ## Next Focus\n(what I plan to continue next)\n\n\
+             Keep each section to 3-5 bullet points. Use practical, encouraging language.\n\
+             Include one short effort note (time/focus/scope) only if the data supports it.\n\
+             Avoid corporate standup tone and avoid burnout/velocity framing.\n\
+             If there's nothing for a section, omit it."
+        }
+    };
+
     let prompt = format!(
-        "Generate a concise daily standup update in markdown with two sections:\n\
-         ## What I Did\n(based on today's activities — what was shipped, reviewed, or completed)\n\
-         ## What I'm Working On\n(based on my open PRs and high-priority Linear tickets)\n\n\
-         Keep each section to 3-5 bullet points. Be specific with ticket/PR numbers.\n\
-         If there's nothing for a section, omit it.\n\n\
+        "{profile_instructions}\n\n\
          Today's activities:\n{activities}\n\n\
          My open/draft PRs:\n{prs}\n\n\
          My urgent/high-priority Linear tickets:\n{tickets}",
@@ -483,7 +503,22 @@ pub async fn get_trends_ai_summary(
     prompt: String,
 ) -> Result<Option<String>, String> {
     let config = state.config.lock().map_err(|e| e.to_string())?.clone();
-    match crate::llm::generate_from_prompt(&config.llm, &prompt).await {
+    let prompt_with_profile = match config.llm.profile {
+        crate::config::LlmProfile::Work => {
+            format!(
+                "Context: this is work activity. Prioritize delivery trends, collaboration patterns, and risk signals.\n\n{}",
+                prompt
+            )
+        }
+        crate::config::LlmProfile::Personal => {
+            format!(
+                "Context: this is personal development activity. Prioritize momentum, learning, consistency, and craft.\n\
+                 De-emphasize corporate productivity framing (velocity/burnout) and include a brief effort note only if evidence is present.\n\n{}",
+                prompt
+            )
+        }
+    };
+    match crate::llm::generate_from_prompt(&config.llm, &prompt_with_profile).await {
         Ok(summary) => Ok(Some(summary)),
         Err(_) => Ok(None),
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,8 @@ pub struct LlmConfig {
     pub enabled: bool,
     #[serde(default = "default_llm_model")]
     pub model: String,
+    #[serde(default)]
+    pub profile: LlmProfile,
 }
 
 impl Default for LlmConfig {
@@ -289,10 +291,29 @@ impl Default for LlmConfig {
         Self {
             enabled: false,
             model: default_llm_model(),
+            profile: LlmProfile::default(),
         }
     }
 }
 
 fn default_llm_model() -> String {
     "claude-haiku-4-5-20251001".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+#[derive(Default)]
+pub enum LlmProfile {
+    #[default]
+    Work,
+    Personal,
+}
+
+impl std::fmt::Display for LlmProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LlmProfile::Work => write!(f, "work"),
+            LlmProfile::Personal => write!(f, "personal"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::exchange_slack_refresh_token,
             commands::get_all_activities,
             commands::clear_cache,
+            commands::clear_llm_cache,
             commands::trigger_sync,
             commands::get_config,
             commands::update_config,

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,4 +1,4 @@
-use crate::config::LlmConfig;
+use crate::config::{LlmConfig, LlmProfile};
 use crate::models::{Activity, Digest, Period};
 
 /// Build the period label for the prompt.
@@ -21,6 +21,17 @@ fn format_activity(a: &Activity) -> String {
     format!("[{}] {}: {}{} - {}", a.source, a.kind, a.title, project, time)
 }
 
+fn profile_summary_instructions(profile: &LlmProfile) -> &'static str {
+    match profile {
+        LlmProfile::Work => {
+            "You are summarizing my work activity. Be concise and highlight what matters: shipped work, key decisions, and collaboration patterns. Group by theme, not by tool. Include blockers/risks only if they are explicit in the data. Skip noise."
+        }
+        LlmProfile::Personal => {
+            "You are summarizing my personal developer activity. Focus on momentum, learning, craft, and consistency. Avoid corporate productivity framing. Mention effort signals (time invested, sustained focus, or scope progressed) without using burnout/velocity language."
+        }
+    }
+}
+
 /// Generate a summary using the `claude` CLI (--print mode).
 /// Falls back to the Anthropic API if `claude` CLI is not available.
 pub async fn generate_summary(
@@ -38,11 +49,11 @@ pub async fn generate_summary(
     }
 
     let prompt = format!(
-        "You are summarizing my work activity for {label}. \
-         Be concise and highlight what matters: shipped work, key decisions, \
-         and collaboration patterns. Group by theme, not by tool. Skip noise. \
+        "{} For {label}. \
          Use markdown formatting. Keep it under 300 words.\n\n\
          Activities:\n{formatted_activities}"
+        ,
+        profile_summary_instructions(&_config.profile),
     );
 
     // Try `claude --print` first (uses existing Claude Code auth, no API key needed)

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -11,6 +11,7 @@ fn default_config_has_expected_values() {
     assert_eq!(config.ttl.warm_minutes, 60);
     assert_eq!(config.ttl.cold_minutes, 1440);
     assert!(!config.llm.enabled);
+    assert_eq!(config.llm.profile.to_string(), "work");
     assert_eq!(config.working_hours.work_start, "09:00");
     assert_eq!(config.working_hours.work_end, "17:00");
     assert_eq!(config.working_hours.working_days.len(), 5);
@@ -26,6 +27,7 @@ fn config_serializes_to_toml_and_back() {
     assert_eq!(parsed.schedule.sync_interval_minutes, config.schedule.sync_interval_minutes);
     assert_eq!(parsed.ttl.warm_minutes, config.ttl.warm_minutes);
     assert_eq!(parsed.llm.enabled, config.llm.enabled);
+    assert_eq!(parsed.llm.profile, config.llm.profile);
     assert_eq!(parsed.working_hours.timezone, config.working_hours.timezone);
 }
 
@@ -61,6 +63,7 @@ enabled = true
     let config: AppConfig = toml::from_str(partial).expect("partial TOML should work");
     assert_eq!(config.schedule.sync_interval_minutes, 15);
     assert!(config.llm.enabled);
+    assert_eq!(config.llm.profile.to_string(), "work");
     // Other fields should have defaults
     assert_eq!(config.ttl.warm_minutes, 60);
 }
@@ -76,4 +79,17 @@ fn github_workflow_enum_serialization() {
     let trunk = GitHubWorkflow::Trunk;
     let json = serde_json::to_string(&trunk).unwrap();
     assert_eq!(json, r#""trunk""#);
+}
+
+#[test]
+fn llm_profile_enum_serialization() {
+    use recap::config::LlmProfile;
+
+    let work = LlmProfile::Work;
+    let json = serde_json::to_string(&work).unwrap();
+    assert_eq!(json, r#""work""#);
+
+    let personal = LlmProfile::Personal;
+    let json = serde_json::to_string(&personal).unwrap();
+    assert_eq!(json, r#""personal""#);
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -109,6 +109,7 @@ const state = {
   gridEditMode: false,
   lastSyncTime: null,
   updateBannerDismissed: false,
+  trendsAdvanced: false,
 };
 
 // ===== Grid Layout System =====
@@ -656,10 +657,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     heatmapContainer: $("#heatmap-container"),
     chartFocus: $("#chart-focus"),
     chartBurnout: $("#chart-burnout"),
+    trendsAdvancedToggle: $("#trends-advanced-toggle"),
 
     // Standup modal
     standupOverlay: $("#standup-overlay"),
     standupClose: $("#standup-close"),
+    standupTitle: $("#standup-title"),
     standupModalContent: $("#standup-modal-content"),
     standupCopy: $("#standup-copy"),
 
@@ -716,6 +719,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     state.config = await invoke('get_config');
   } catch {}
+  updateProfileModeUI();
   await loadDashboard();
 
   // Check for updates after UI is loaded
@@ -794,7 +798,7 @@ function bindEvents() {
 
   // Briefing refresh
   dom.briefingRefresh.addEventListener("click", () => {
-    const key = cacheKey();
+    const key = briefingCacheKey();
     delete state.llmCache[key];
     fetchBriefing();
   });
@@ -870,6 +874,67 @@ function bindEvents() {
       }
     }
   });
+
+  dom.trendsAdvancedToggle?.addEventListener("click", () => {
+    state.trendsAdvanced = !state.trendsAdvanced;
+    applyTrendsProfileMode();
+  });
+}
+
+function isPersonalProfile() {
+  return (state.config?.llm?.profile || "work") === "personal";
+}
+
+function setHidden(el, hidden) {
+  if (!el) return;
+  el.classList.toggle("hidden", !!hidden);
+}
+
+function applyOverviewProfileMode() {
+  const personal = isPersonalProfile();
+  setHidden(document.getElementById("card-pr-stats"), personal);
+  setHidden(document.getElementById("card-linear"), personal);
+}
+
+function applyTrendsProfileMode() {
+  const personal = isPersonalProfile();
+  const toggle = dom.trendsAdvancedToggle;
+  if (!toggle) return;
+
+  const advancedTargets = [
+    dom.anomalyAlerts,
+    dom.chartForecast?.closest(".card"),
+    dom.chartVelocity?.closest(".card"),
+    dom.chartCycleTime?.closest(".card"),
+    document.getElementById("cluster-container")?.closest(".card"),
+    document.getElementById("project-prediction-container")?.closest(".card"),
+    dom.chartFocus?.closest(".card"),
+    dom.chartBurnout?.closest(".card"),
+  ];
+
+  if (!personal) {
+    toggle.classList.add("hidden");
+    advancedTargets.forEach((el) => setHidden(el, false));
+    return;
+  }
+
+  toggle.classList.remove("hidden");
+  toggle.innerHTML = state.trendsAdvanced ? "Advanced &#9652;" : "Advanced &#9662;";
+  advancedTargets.forEach((el) => setHidden(el, !state.trendsAdvanced));
+}
+
+function updateProfileModeUI() {
+  const personal = isPersonalProfile();
+  if (dom.actionStandup) {
+    dom.actionStandup.innerHTML = personal
+      ? "&#x1f4dd; Generate Recap"
+      : "&#x1f4cb; Generate Standup";
+  }
+  if (dom.standupTitle) {
+    dom.standupTitle.textContent = personal ? "Personal Recap" : "Daily Standup";
+  }
+  applyOverviewProfileMode();
+  applyTrendsProfileMode();
 }
 
 // ===== View Switching =====
@@ -1064,6 +1129,18 @@ function cacheKey() {
   return `${state.period}:${state.date || "now"}`;
 }
 
+function llmProfileKey() {
+  return state.config?.llm?.profile || "work";
+}
+
+function briefingCacheKey() {
+  return `${llmProfileKey()}:${cacheKey()}`;
+}
+
+function standupCacheKey() {
+  return `${llmProfileKey()}:${cacheKey()}`;
+}
+
 function invokeArgs() {
   const args = { period: state.period };
   if (state.date) args.date = state.date;
@@ -1092,6 +1169,7 @@ async function loadDashboard() {
       dom.emptyState.style.display = "";
       dom.dashboard.style.display = "none";
       if (hlEl) hlEl.style.display = "none";
+      applyOverviewProfileMode();
       return;
     }
 
@@ -1104,6 +1182,7 @@ async function loadDashboard() {
     renderFeatures(features);
     renderLinearProgress(digest.activities);
     renderActivityTable(digest.activities);
+    applyOverviewProfileMode();
 
     // Initialize 12-column grid layout
     initGridSystem();
@@ -1123,10 +1202,13 @@ function renderHeadlineMetrics(digest) {
   const stats = digest?.stats;
   if (!stats) return;
 
+  const personal = isPersonalProfile();
   const total = stats.total_activities || 0;
   const merged = stats.by_kind?.["pr_merged"] || 0;
   const reviewed = stats.by_kind?.["pr_reviewed"] || 0;
   const issuesCompleted = stats.by_kind?.["issue_completed"] || 0;
+  const commits = stats.by_kind?.["commit_pushed"] || 0;
+  const issuesClosed = stats.by_kind?.["issue_closed"] || 0;
 
   const set = (id, value) => {
     const el = document.querySelector(`#${id} .headline-value`);
@@ -1134,9 +1216,18 @@ function renderHeadlineMetrics(digest) {
   };
 
   set("hl-total", total);
-  set("hl-prs", merged);
-  set("hl-reviews", reviewed);
-  set("hl-issues", issuesCompleted);
+  set("hl-prs", personal ? commits : merged);
+  set("hl-reviews", personal ? (merged + reviewed) : reviewed);
+  set("hl-issues", personal ? (issuesCompleted + issuesClosed) : issuesCompleted);
+
+  const setLabel = (id, value) => {
+    const el = document.querySelector(`#${id} .headline-label`);
+    if (el) el.textContent = value;
+  };
+  setLabel("hl-total", personal ? "Activity Signals" : "Total Activities");
+  setLabel("hl-prs", personal ? "Commits" : "PRs Merged");
+  setLabel("hl-reviews", personal ? "PR Activity" : "Reviews");
+  setLabel("hl-issues", personal ? "Issues Closed" : "Issues Completed");
 }
 
 // ===== Activity Over Time Chart =====
@@ -1842,7 +1933,7 @@ function renderStatCards(stats) {
 // ===== Daily Briefing (LLM) =====
 
 async function fetchBriefing() {
-  const key = cacheKey();
+  const key = briefingCacheKey();
 
   if (state.llmCache[key] !== undefined) {
     renderBriefing(state.llmCache[key]);
@@ -1875,7 +1966,8 @@ function renderBriefing(summary) {
 
 async function openStandupModal() {
   dom.standupOverlay.style.display = '';
-  const key = cacheKey();
+  const key = standupCacheKey();
+  const personal = isPersonalProfile();
   if (state.standupCache[key]) {
     state.standupText = state.standupCache[key];
     dom.standupModalContent.innerHTML = renderMarkdown(state.standupText);
@@ -1888,7 +1980,9 @@ async function openStandupModal() {
     const standup = await invoke('get_standup', args);
     state.standupCache[key] = standup;
     state.standupText = standup;
-    dom.standupModalContent.innerHTML = standup ? renderMarkdown(standup) : '<span class="briefing-disabled">Could not generate standup. Is Claude CLI installed?</span>';
+    dom.standupModalContent.innerHTML = standup
+      ? renderMarkdown(standup)
+      : `<span class="briefing-disabled">Could not generate ${personal ? "recap" : "standup"}. Is Claude CLI installed?</span>`;
   } catch (err) {
     dom.standupModalContent.innerHTML = `<span class="briefing-disabled">Error: ${escapeHtml(String(err))}</span>`;
   }
@@ -1905,6 +1999,7 @@ async function openSettingsModal() {
   try {
     state.config = await invoke('get_config');
   } catch {}
+  updateProfileModeUI();
   await refreshAuthStatus();
   renderUpdateStatus();
   renderSettingsConnections();
@@ -2076,12 +2171,35 @@ function renderSettingsPrefs() {
   if (!state.config) { dom.settingsPrefs.innerHTML = ''; return; }
   const c = state.config;
   const llm = c.llm || {};
+  const personalProfile = (llm.profile || "work") === "personal";
   const wh = c.working_hours || {};
   const workingDays = wh.working_days || ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
   const allDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const dayCheckboxes = allDays.map(d =>
     `<label class="pref-day-label"><input type="checkbox" class="pref-day-cb" value="${d}"${workingDays.includes(d) ? ' checked' : ''}> ${d}</label>`
   ).join('');
+  const workingHoursSection = personalProfile
+    ? `<div class="pref-row">
+         <div class="pref-hint">Working-hours settings are hidden in Personal mode. Switch to Work profile to configure burnout/working-hours analysis.</div>
+       </div>`
+    : `<div class="pref-section-divider">Working Hours</div>
+       <div class="pref-row">
+         <label class="pref-label">Work start</label>
+         <input class="pref-input pref-input-time" type="time" id="pref-work-start" value="${escapeAttr(wh.work_start || '09:00')}">
+       </div>
+       <div class="pref-row">
+         <label class="pref-label">Work end</label>
+         <input class="pref-input pref-input-time" type="time" id="pref-work-end" value="${escapeAttr(wh.work_end || '17:00')}">
+       </div>
+       <div class="pref-row pref-row-days">
+         <label class="pref-label">Working days</label>
+         <div class="pref-days">${dayCheckboxes}</div>
+       </div>
+       <div class="pref-row">
+         <label class="pref-label">Timezone</label>
+         <input class="pref-input" type="text" id="pref-timezone" value="${escapeAttr(wh.timezone || 'UTC')}" placeholder="UTC, Europe/London, America/New_York…">
+         <div class="pref-hint">IANA timezone name</div>
+       </div>`;
   dom.settingsPrefs.innerHTML = `
     <div class="pref-row">
       <label class="pref-label">Sync interval (min)</label>
@@ -2120,24 +2238,7 @@ function renderSettingsPrefs() {
       <input class="pref-input" type="text" id="pref-ignored-channels" value="${escapeAttr((c.slack?.ignored_channels || []).join(', '))}" placeholder="github-prs, graphite-*">
       <div class="pref-hint">Comma-separated, supports glob patterns</div>
     </div>
-    <div class="pref-section-divider">Working Hours</div>
-    <div class="pref-row">
-      <label class="pref-label">Work start</label>
-      <input class="pref-input pref-input-time" type="time" id="pref-work-start" value="${escapeAttr(wh.work_start || '09:00')}">
-    </div>
-    <div class="pref-row">
-      <label class="pref-label">Work end</label>
-      <input class="pref-input pref-input-time" type="time" id="pref-work-end" value="${escapeAttr(wh.work_end || '17:00')}">
-    </div>
-    <div class="pref-row pref-row-days">
-      <label class="pref-label">Working days</label>
-      <div class="pref-days">${dayCheckboxes}</div>
-    </div>
-    <div class="pref-row">
-      <label class="pref-label">Timezone</label>
-      <input class="pref-input" type="text" id="pref-timezone" value="${escapeAttr(wh.timezone || 'UTC')}" placeholder="UTC, Europe/London, America/New_York…">
-      <div class="pref-hint">IANA timezone name</div>
-    </div>
+    ${workingHoursSection}
     <div class="pref-save-row">
       <button class="btn" id="pref-save-btn">Save Preferences</button>
     </div>
@@ -2320,6 +2421,7 @@ function renderDebugPage() {
 
 async function savePreferences() {
   if (!state.config) return;
+  const previousProfile = state.config.llm?.profile || "work";
   state.config.schedule.sync_interval_minutes = parseInt(document.getElementById('pref-sync-interval')?.value) || 5;
   state.config.schedule.daily_reminder_time = document.getElementById('pref-reminder-time')?.value || '17:00';
   const ghUsername = document.getElementById('pref-gh-username')?.value?.trim();
@@ -2327,19 +2429,40 @@ async function savePreferences() {
   state.config.github.workflow = document.getElementById('pref-gh-workflow')?.value || 'pr';
   if (!state.config.llm) state.config.llm = {};
   state.config.llm.profile = document.getElementById('pref-llm-profile')?.value || 'work';
+  const profileChanged = previousProfile !== state.config.llm.profile;
   const slackUserId = document.getElementById('pref-slack-userid')?.value?.trim();
   state.config.slack.user_id = slackUserId || null;
   const ignoredStr = document.getElementById('pref-ignored-channels')?.value || '';
   state.config.slack.ignored_channels = ignoredStr.split(',').map(s => s.trim()).filter(Boolean);
   // Working hours
   if (!state.config.working_hours) state.config.working_hours = {};
-  state.config.working_hours.work_start = document.getElementById('pref-work-start')?.value || '09:00';
-  state.config.working_hours.work_end = document.getElementById('pref-work-end')?.value || '17:00';
-  state.config.working_hours.timezone = document.getElementById('pref-timezone')?.value?.trim() || 'UTC';
-  const checkedDays = [...document.querySelectorAll('.pref-day-cb:checked')].map(cb => cb.value);
-  state.config.working_hours.working_days = checkedDays;
+  const workStartEl = document.getElementById('pref-work-start');
+  const workEndEl = document.getElementById('pref-work-end');
+  const timezoneEl = document.getElementById('pref-timezone');
+  if (workStartEl && workEndEl && timezoneEl) {
+    state.config.working_hours.work_start = workStartEl.value || '09:00';
+    state.config.working_hours.work_end = workEndEl.value || '17:00';
+    state.config.working_hours.timezone = timezoneEl.value?.trim() || 'UTC';
+    const checkedDays = [...document.querySelectorAll('.pref-day-cb:checked')].map(cb => cb.value);
+    state.config.working_hours.working_days = checkedDays;
+  }
   try {
     await invoke('update_config', { config: state.config });
+    if (profileChanged) {
+      await invoke('clear_llm_cache');
+      state.llmCache = {};
+      state.standupCache = {};
+      state.briefingText = null;
+      state.standupText = null;
+      state.trendsAdvanced = false;
+      updateProfileModeUI();
+      await loadDashboard();
+      if (state.activeView === 'trends') {
+        await loadTrendsView();
+      }
+    } else {
+      updateProfileModeUI();
+    }
     showToast('Preferences saved!', 'success');
   } catch (err) {
     showToast(`Failed to save: ${err}`, 'error');
@@ -2495,6 +2618,7 @@ async function loadTrendsView() {
     renderBurnoutChart(data.burnout);
     // Generate AI summary async (don't block)
     generateTrendsAiSummary(data);
+    applyTrendsProfileMode();
   } catch (err) {
     showToast(`Failed to load trends: ${err}`, 'error');
   }
@@ -2559,11 +2683,12 @@ Active projects: ${focusProjects}`;
 }
 
 function renderTrendsHeader(productivity, prediction) {
+  const personal = isPersonalProfile();
   const trendIcon = productivity.trend === 'improving' ? '\u2197' : productivity.trend === 'declining' ? '\u2198' : '\u2192';
   dom.trendsPredictions.innerHTML = renderStatCards([
-    { value: productivity.current_score, label: `Productivity ${trendIcon}` },
+    { value: productivity.current_score, label: `${personal ? 'Momentum' : 'Productivity'} ${trendIcon}` },
     { value: productivity.baseline_avg, label: '12-wk Average' },
-    { value: prediction.confidence.charAt(0).toUpperCase() + prediction.confidence.slice(1), label: 'Forecast Confidence' },
+    { value: prediction.confidence.charAt(0).toUpperCase() + prediction.confidence.slice(1), label: personal ? 'Signal Confidence' : 'Forecast Confidence' },
     { value: productivity.trend.charAt(0).toUpperCase() + productivity.trend.slice(1), label: 'Trend' },
   ]);
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -2075,6 +2075,7 @@ async function exchangeSlackToken() {
 function renderSettingsPrefs() {
   if (!state.config) { dom.settingsPrefs.innerHTML = ''; return; }
   const c = state.config;
+  const llm = c.llm || {};
   const wh = c.working_hours || {};
   const workingDays = wh.working_days || ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
   const allDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
@@ -2101,6 +2102,14 @@ function renderSettingsPrefs() {
         <option value="trunk"${c.github?.workflow === 'trunk' ? ' selected' : ''}>Trunk-based (commits to main)</option>
       </select>
       <div class="pref-hint">PR-based shows PRs first; trunk-based emphasizes commits</div>
+    </div>
+    <div class="pref-row">
+      <label class="pref-label">LLM profile</label>
+      <select class="pref-input" id="pref-llm-profile">
+        <option value="work"${(llm.profile || 'work') === 'work' ? ' selected' : ''}>Work</option>
+        <option value="personal"${llm.profile === 'personal' ? ' selected' : ''}>Personal</option>
+      </select>
+      <div class="pref-hint">Personal mode favors momentum/effort framing over velocity/burnout language</div>
     </div>
     <div class="pref-row">
       <label class="pref-label">Slack user ID</label>
@@ -2316,6 +2325,8 @@ async function savePreferences() {
   const ghUsername = document.getElementById('pref-gh-username')?.value?.trim();
   state.config.github.username = ghUsername || null;
   state.config.github.workflow = document.getElementById('pref-gh-workflow')?.value || 'pr';
+  if (!state.config.llm) state.config.llm = {};
+  state.config.llm.profile = document.getElementById('pref-llm-profile')?.value || 'work';
   const slackUserId = document.getElementById('pref-slack-userid')?.value?.trim();
   state.config.slack.user_id = slackUserId || null;
   const ignoredStr = document.getElementById('pref-ignored-channels')?.value || '';
@@ -2506,12 +2517,25 @@ async function generateTrendsAiSummary(data) {
     `${pp.project} (${Math.round(pp.probability * 100)}%)`
   ).join(', ');
   const focusProjects = Object.keys(data.focus.projects).join(', ');
+  const llmProfile = state.config?.llm?.profile || 'work';
 
   const forecastLines = Object.entries(f.forecasts).map(([kind, vals]) =>
     `${kind}: ${vals.map(v => v.toFixed(1)).join(', ')}`
   ).join('; ');
 
-  const prompt = `You are analyzing a software engineer's 12-week activity trends. Give a concise, insightful 3-4 bullet analysis in markdown. Be specific with numbers. Highlight what's notable — don't just restate data.
+  const prompt = llmProfile === 'personal'
+    ? `You are analyzing a personal developer's 12-week activity trends. Give a concise, insightful 3-4 bullet analysis in markdown.
+Focus on momentum, consistency, and craft development. Mention effort signals carefully (sustained focus/time investment) only when evidence is clear.
+Avoid corporate performance framing and do not over-index on burnout language.
+
+Momentum: current score ${p.current_score}, baseline avg ${p.baseline_avg}, trend ${p.trend}
+Effort note: off-hours trend ${b.trend_direction}, latest off-hours ${b.off_hours_pct.slice(-1)[0]?.toFixed(1) || 0}%
+Forecast (next 3 weeks): ${forecastLines}
+Anomalies: ${anomalyDesc}
+Day types: ${clusterDesc}
+Tomorrow prediction: ${projPred}
+Active projects: ${focusProjects}`
+    : `You are analyzing a software engineer's 12-week activity trends. Give a concise, insightful 3-4 bullet analysis in markdown. Be specific with numbers. Highlight what's notable — don't just restate data.
 
 Productivity: current score ${p.current_score}, baseline avg ${p.baseline_avg}, trend ${p.trend}
 Burnout: off-hours trend ${b.trend_direction}, latest off-hours ${b.off_hours_pct.slice(-1)[0]?.toFixed(1) || 0}%

--- a/ui/index.html
+++ b/ui/index.html
@@ -381,6 +381,9 @@
 
         <!-- Productivity Score + Predictions -->
         <div class="source-stats-row" id="trends-predictions"></div>
+        <div class="trends-controls">
+          <button id="trends-advanced-toggle" class="btn btn-tiny">Advanced &#9662;</button>
+        </div>
 
         <!-- Anomaly Alerts -->
         <div id="anomaly-alerts"></div>
@@ -472,11 +475,11 @@
 
   <!-- Standup Modal -->
   <div id="standup-overlay" class="modal-overlay" style="display:none">
-    <div class="modal standup-modal">
-      <div class="modal-header">
-        <h2>Daily Standup</h2>
-        <button id="standup-close" class="btn btn-icon">&times;</button>
-      </div>
+      <div class="modal standup-modal">
+        <div class="modal-header">
+          <h2 id="standup-title">Daily Standup</h2>
+          <button id="standup-close" class="btn btn-icon">&times;</button>
+        </div>
       <div id="standup-modal-content" class="standup-content"></div>
       <div class="modal-footer">
         <button id="standup-copy" class="btn">&#x1f4cb; Copy to Clipboard</button>

--- a/ui/style.css
+++ b/ui/style.css
@@ -1731,6 +1731,12 @@ body {
   gap: 16px;
 }
 
+.trends-controls {
+  display: flex;
+  justify-content: flex-end;
+  margin: 8px 0 12px;
+}
+
 .heatmap-container {
   padding: 8px 0;
 }


### PR DESCRIPTION
## Problem
The app currently uses a single work-oriented LLM framing for summaries and trend commentary. For personal development tracking, that tone over-emphasizes velocity/burnout language and under-emphasizes momentum, learning, and effort.

## Solution
- add `llm.profile` config with `work` (default) and `personal`
- wire profile-aware prompting for digest summaries
- wire profile-aware prompting for standup/recap generation and trends AI summary
- include profile in LLM cache keys so switching profile regenerates outputs
- add Settings UI to choose LLM profile
- update config examples/docs and config tests for the new profile enum/default

## Validation
- `cargo test --quiet`
